### PR TITLE
增加返回字节数组方法 

### DIFF
--- a/demos/Http/HttpServerDemo/cpp/main.cpp
+++ b/demos/Http/HttpServerDemo/cpp/main.cpp
@@ -16,12 +16,13 @@ int main(int argc, char *argv[])
         // 回调发生在新的线程内，不是主线程，请注意线程安全
         // 若阻塞了此回调，那么新的连接将不会得到处理（默认情况下有2个线程可以阻塞2次，第3个连接将不会被处理）
 
-        session->replyText( QString( "url:%1\nbody:%2" ).arg( session->requestUrl(), QString( session->requestBody() ) ) );
+//        session->replyText( QString( "url:%1\nbody:%2" ).arg( session->requestUrl(), QString( session->requestBody() ) ) );
 //        session->replyRedirects( QUrl( "http://www.baidu.com" ) );
 //        session->replyJsonObject( { { { "message", "ok" } } } );
 //        session->replyJsonArray( { "a", "b", "c" } );
 //        session->replyFile( "/Users/jason/Desktop/Test1.Test2" );
 //        session->replyImage( QImage( "/Users/jason/Desktop/Test.png" ) );
+        session->replyBytes(QByteArray(4,'\x24')); // $$$$
 
         // 注1：因为一个session对应一个单一的HTTP请求，所以session只能reply一次
         // 注2：在reply后，session的生命周期不可控，所以reply后不要再调用session的接口了

--- a/demos/Http/HttpServerDemo/cpp/main.cpp
+++ b/demos/Http/HttpServerDemo/cpp/main.cpp
@@ -16,13 +16,13 @@ int main(int argc, char *argv[])
         // 回调发生在新的线程内，不是主线程，请注意线程安全
         // 若阻塞了此回调，那么新的连接将不会得到处理（默认情况下有2个线程可以阻塞2次，第3个连接将不会被处理）
 
-//        session->replyText( QString( "url:%1\nbody:%2" ).arg( session->requestUrl(), QString( session->requestBody() ) ) );
+        session->replyText( QString( "url:%1\nbody:%2" ).arg( session->requestUrl(), QString( session->requestBody() ) ) );
 //        session->replyRedirects( QUrl( "http://www.baidu.com" ) );
 //        session->replyJsonObject( { { { "message", "ok" } } } );
 //        session->replyJsonArray( { "a", "b", "c" } );
 //        session->replyFile( "/Users/jason/Desktop/Test1.Test2" );
 //        session->replyImage( QImage( "/Users/jason/Desktop/Test.png" ) );
-        session->replyBytes(QByteArray(4,'\x24')); // $$$$
+//        session->replyBytes(QByteArray(4,'\x24')); // $$$$
 
         // 注1：因为一个session对应一个单一的HTTP请求，所以session只能reply一次
         // 注2：在reply后，session的生命周期不可控，所以reply后不要再调用session的接口了

--- a/library/JQLibrary/include/JQHttpServer.h
+++ b/library/JQLibrary/include/JQHttpServer.h
@@ -95,6 +95,8 @@ public slots:
 
     void replyImage(const QImage &image, const int &httpStatusCode = 200);
 
+    void replyBytes(const QByteArray &bytes, const int &httpStatusCode = 200);
+
     void replyOptions();
 
 private:


### PR DESCRIPTION
添加这样一个接口，可以返回内存中存放的二进制数据。
应用场景：服务端在内存中维护一段实时更新的数据。当客户端请求这段数据时，将其返回；
改动：
1. 增加 http 头部字符串：replyBytesFormat；
2. 增加 replyBytes 方法，参照 replyImage 实现；