### PR TITLE
fix:解决arm平台qt5.9存在的get https会造成线程开启暴涨不释放的情况；修复低版本qt 网络会变成NotAccessible问题

### DIFF
--- a/library/JQLibrary/include/jqhttpserver.h
+++ b/library/JQLibrary/include/jqhttpserver.h
@@ -384,7 +384,7 @@ private:
     QSharedPointer< JQHttpServer::TcpServerManage > httpServerManage_;
     QSharedPointer< JQHttpServer::SslServerManage > httpsServerManage_;
 
-    QString                                     serviceUuid_;
+    QString serviceUuid_;
     QMap< QString, QMap< QString, ApiConfig > > schedules_;    // apiMethod -> apiName -> API
     QMap< QString, std::function< void( const QPointer< JQHttpServer::Session > &session ) > > schedules2_; // apiPathPrefix -> callback
     QPointer< QObject > certificateVerifier_;

--- a/library/JQLibrary/include/jqnet.h
+++ b/library/JQLibrary/include/jqnet.h
@@ -36,12 +36,14 @@
 #include <functional>
 
 // Qt lib import
+#include <QPointer>
 #include <QSharedPointer>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QHttpMultiPart>
 #include <QNetworkInterface>
 #include <QNetworkAddressEntry>
+#include <QMutex>
 
 // JQLibrary lib import
 #include <JQDeclare>
@@ -73,7 +75,7 @@ public:
     ~HTTP() = default;
 
 public:
-    inline QNetworkAccessManager &manage() { return manage_; }
+    QNetworkAccessManager &manage();
 
 
     bool get(
@@ -203,7 +205,8 @@ private:
         );
 
 private:
-    QNetworkAccessManager manage_;
+   inline static QMap<QThread *, QPointer<QNetworkAccessManager>> manageMap_;
+   static QMutex manageMutex_;
 };
 
 }


### PR DESCRIPTION
1. 解决arm linux 平台下的qt5.9 get https链接会导致线程一直开启不释放，资源泄漏
2. 解决旧版本QNetworkAccessManager 会出现QNetworkAccessManager::NotAccessible的问题