### PR TITLE
revert const removal

### DIFF
--- a/library/JQLibrary/include/jqhttpserver.h
+++ b/library/JQLibrary/include/jqhttpserver.h
@@ -112,23 +112,23 @@ public:
 #endif
 
 public slots:
-    void replyText(const QString &replyData, const int &httpStatusCode = 200);
+    void replyText(const QString &replyData, const int httpStatusCode = 200);
 
-    void replyRedirects(const QUrl &targetUrl, const int &httpStatusCode = 302);
+    void replyRedirects(const QUrl &targetUrl, const int httpStatusCode = 302);
 
-    void replyJsonObject(const QJsonObject &jsonObject, const int &httpStatusCode = 200);
+    void replyJsonObject(const QJsonObject &jsonObject, const int httpStatusCode = 200);
 
-    void replyJsonArray(const QJsonArray &jsonArray, const int &httpStatusCode = 200);
+    void replyJsonArray(const QJsonArray &jsonArray, const int httpStatusCode = 200);
 
-    void replyFile(const QString &filePath, const int &httpStatusCode = 200);
+    void replyFile(const QString &filePath, const int httpStatusCode = 200);
 
-    void replyFile(const QString &fileName, const QByteArray &fileData, const int &httpStatusCode = 200);
+    void replyFile(const QString &fileName, const QByteArray &fileData, const int httpStatusCode = 200);
 
-    void replyImage(const QImage &image, const QString &format = "PNG", const int &httpStatusCode = 200);
+    void replyImage(const QImage &image, const QString &format = "PNG", const int httpStatusCode = 200);
 
-    void replyImage(const QString &imageFilePath, const int &httpStatusCode = 200);
+    void replyImage(const QString &imageFilePath, const int httpStatusCode = 200);
 
-    void replyBytes(const QByteArray &bytes, const QString &contentType = "application/octet-stream", const int &httpStatusCode = 200, const QString &exHeader = QString());
+    void replyBytes(const QByteArray &bytes, const QString &contentType = "application/octet-stream", const int httpStatusCode = 200, const QString &exHeader = QString());
 
     void replyOptions();
 
@@ -137,7 +137,7 @@ private:
 
     void analyseBufferSetup2();
 
-    void onBytesWritten(const qint64 &written);
+    void onBytesWritten(const qint64 written);
 
     void onStateChanged(const QAbstractSocket::SocketState &socketState);
 
@@ -175,7 +175,7 @@ class JQLIBRARY_EXPORT AbstractManage: public QObject
     Q_DISABLE_COPY( AbstractManage )
 
 public:
-    AbstractManage(const int &handleMaxThreadCount);
+    AbstractManage(const int handleMaxThreadCount);
 
     virtual ~AbstractManage() override;
 
@@ -227,11 +227,11 @@ class JQLIBRARY_EXPORT TcpServerManage: public AbstractManage
     Q_DISABLE_COPY( TcpServerManage )
 
 public:
-    TcpServerManage(const int &handleMaxThreadCount = 2);
+    TcpServerManage(const int handleMaxThreadCount = 2);
 
     virtual ~TcpServerManage() override;
 
-    bool listen( const QHostAddress &address, const quint16 &port );
+    bool listen( const QHostAddress &address, const quint16 port );
 
 private:
     bool isRunning() override;
@@ -256,13 +256,13 @@ class JQLIBRARY_EXPORT SslServerManage: public AbstractManage
     Q_DISABLE_COPY( SslServerManage )
 
 public:
-    SslServerManage(const int &handleMaxThreadCount = 2);
+    SslServerManage(const int handleMaxThreadCount = 2);
 
     virtual ~SslServerManage() override;
 
     bool listen(
         const QHostAddress &address,
-        const quint16 &     port,
+        const quint16       port,
         const QString &     crtFilePath,
         const QString &     keyFilePath );
 
@@ -349,15 +349,15 @@ public:
     static void reply(
         const QPointer< JQHttpServer::Session > &session,
         const QJsonObject &data,
-        const bool &isSucceed = true,
+        const bool isSucceed = true,
         const QString &message = { },
-        const int &httpStatusCode = 200 );
+        const int httpStatusCode = 200 );
 
     static void reply(
         const QPointer< JQHttpServer::Session > &session,
-        const bool &isSucceed = true,
+        const bool isSucceed = true,
         const QString &message = { },
-        const int &httpStatusCode = 200 );
+        const int httpStatusCode = 200 );
 
 
     virtual void httpGetPing( const QPointer< JQHttpServer::Session > &session );
@@ -373,7 +373,7 @@ private:
     void onSessionAccepted( const QPointer< JQHttpServer::Session > &session );
 
 
-    static QString snakeCaseToCamelCase(const QString &source, const bool &firstCharUpper = false);
+    static QString snakeCaseToCamelCase(const QString &source, const bool firstCharUpper = false);
 
     static QList< QVariantMap > variantListToListVariantMap(const QVariantList &source);
 

--- a/library/JQLibrary/include/jqnet.h
+++ b/library/JQLibrary/include/jqnet.h
@@ -53,16 +53,16 @@ namespace JQNet
 
 QNetworkAddressEntry getFirstNetworkAddressEntry();
 
-QPair< QNetworkAddressEntry, QNetworkInterface > getFirstNetworkAddressEntryAndInterface(const bool &ridVm = true);
+QPair< QNetworkAddressEntry, QNetworkInterface > getFirstNetworkAddressEntryAndInterface(const bool ridVm = true);
 
-QList< QPair< QNetworkAddressEntry, QNetworkInterface > > getNetworkAddressEntryAndInterface(const bool &ridVm = true);
+QList< QPair< QNetworkAddressEntry, QNetworkInterface > > getNetworkAddressEntryAndInterface(const bool ridVm = true);
 
 QString getHostName();
 
-bool tcpReachable(const QString &hostName, const quint16 &port, const int &timeout = 5000);
+bool tcpReachable(const QString &hostName, const quint16 port, const int timeout = 5000);
 
 #ifdef JQFOUNDATION_LIB
-bool pingReachable(const QString &address, const int &timeout = 300);
+bool pingReachable(const QString &address, const int timeout = 300);
 #endif
 
 class JQLIBRARY_EXPORT HTTP
@@ -81,27 +81,27 @@ public:
     bool get(
             const QNetworkRequest &request,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     void get(
             const QNetworkRequest &request,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &data) > &onFinished,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &code, const QByteArray &data) > &onError,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     bool deleteResource(
             const QNetworkRequest &request,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     void deleteResource(
             const QNetworkRequest &request,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &data) > &onFinished,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &code, const QByteArray &data) > &onError,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     bool post(
@@ -109,14 +109,14 @@ public:
             const QByteArray &body,
             QList< QNetworkReply::RawHeaderPair > &receiveRawHeaderPairs,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     bool post(
             const QNetworkRequest &request,
             const QSharedPointer< QHttpMultiPart > &multiPart,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     void post(
@@ -124,21 +124,21 @@ public:
             const QByteArray &body,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &data) > &onFinished,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &code, const QByteArray &data) > &onError,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     bool put(
             const QNetworkRequest &request,
             const QByteArray &body,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     bool put(
             const QNetworkRequest &request,
             const QSharedPointer< QHttpMultiPart > &multiPart,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     void put(
@@ -146,7 +146,7 @@ public:
             const QByteArray &body,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &data) > &onFinished,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &code, const QByteArray &data) > &onError,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
 #if !( defined Q_OS_LINUX ) && ( QT_VERSION >= QT_VERSION_CHECK( 5, 9, 0 ) )
@@ -154,7 +154,7 @@ public:
             const QNetworkRequest &request,
             const QByteArray &body,
             QByteArray &receiveBuffer,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 
     void patch(
@@ -162,43 +162,43 @@ public:
             const QByteArray &body,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &data) > &onFinished,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &code, const QByteArray &data) > &onError,
-            const int &timeout = 30 * 1000
+            const int timeout = 30 * 1000
         );
 #endif
 
 
-    static QPair< bool, QByteArray > get(const QString &url, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > get(const QString &url, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > get(const QNetworkRequest &request, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > get(const QNetworkRequest &request, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > deleteResource(const QString &url, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > deleteResource(const QString &url, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > deleteResource(const QNetworkRequest &request, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > deleteResource(const QNetworkRequest &request, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > post(const QString &url, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > post(const QString &url, const QByteArray &body, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > post(const QNetworkRequest &request, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > post(const QNetworkRequest &request, const QByteArray &body, const int timeout = 30 * 1000);
 
-    static QPair< bool, QPair< QList< QNetworkReply::RawHeaderPair >, QByteArray > > post2(const QNetworkRequest &request, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QPair< QList< QNetworkReply::RawHeaderPair >, QByteArray > > post2(const QNetworkRequest &request, const QByteArray &body, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > post(const QNetworkRequest &request, const QSharedPointer< QHttpMultiPart > &multiPart, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > post(const QNetworkRequest &request, const QSharedPointer< QHttpMultiPart > &multiPart, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > put(const QString &url, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > put(const QString &url, const QByteArray &body, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > put(const QNetworkRequest &request, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > put(const QNetworkRequest &request, const QByteArray &body, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > put(const QNetworkRequest &request, const QSharedPointer< QHttpMultiPart > &multiPart, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > put(const QNetworkRequest &request, const QSharedPointer< QHttpMultiPart > &multiPart, const int timeout = 30 * 1000);
 
 #if !( defined Q_OS_LINUX ) && ( QT_VERSION >= QT_VERSION_CHECK( 5, 9, 0 ) )
-    static QPair< bool, QByteArray > patch(const QString &url, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > patch(const QString &url, const QByteArray &body, const int timeout = 30 * 1000);
 
-    static QPair< bool, QByteArray > patch(const QNetworkRequest &request, const QByteArray &body, const int &timeout = 30 * 1000);
+    static QPair< bool, QByteArray > patch(const QNetworkRequest &request, const QByteArray &body, const int timeout = 30 * 1000);
 #endif
 
 private:
     void handle(
             QNetworkReply *reply,
-            const int &timeout,
+            const int timeout,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &data) > &onFinished,
             const std::function< void(const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &code, const QByteArray &data) > &onError,
             const std::function< void() > &onTimeout

--- a/library/JQLibrary/src/jqhttpserver.cpp
+++ b/library/JQLibrary/src/jqhttpserver.cpp
@@ -343,7 +343,7 @@ QSslCertificate JQHttpServer::Session::peerCertificate() const
 }
 #endif
 
-void JQHttpServer::Session::replyText(const QString &replyData, const int &httpStatusCode)
+void JQHttpServer::Session::replyText(const QString &replyData, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyText" )
 
@@ -375,7 +375,7 @@ void JQHttpServer::Session::replyText(const QString &replyData, const int &httpS
     socket_->write( data );
 }
 
-void JQHttpServer::Session::replyRedirects(const QUrl &targetUrl, const int &httpStatusCode)
+void JQHttpServer::Session::replyRedirects(const QUrl &targetUrl, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyRedirects" )
 
@@ -400,7 +400,7 @@ void JQHttpServer::Session::replyRedirects(const QUrl &targetUrl, const int &htt
     socket_->write( data );
 }
 
-void JQHttpServer::Session::replyJsonObject(const QJsonObject &jsonObject, const int &httpStatusCode)
+void JQHttpServer::Session::replyJsonObject(const QJsonObject &jsonObject, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyJsonObject" )
 
@@ -428,7 +428,7 @@ void JQHttpServer::Session::replyJsonObject(const QJsonObject &jsonObject, const
     socket_->write( buffer );
 }
 
-void JQHttpServer::Session::replyJsonArray(const QJsonArray &jsonArray, const int &httpStatusCode)
+void JQHttpServer::Session::replyJsonArray(const QJsonArray &jsonArray, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyJsonArray" )
 
@@ -456,7 +456,7 @@ void JQHttpServer::Session::replyJsonArray(const QJsonArray &jsonArray, const in
     socket_->write( buffer );
 }
 
-void JQHttpServer::Session::replyFile(const QString &filePath, const int &httpStatusCode)
+void JQHttpServer::Session::replyFile(const QString &filePath, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyFile" )
 
@@ -494,7 +494,7 @@ void JQHttpServer::Session::replyFile(const QString &filePath, const int &httpSt
     socket_->write( data );
 }
 
-void JQHttpServer::Session::replyFile(const QString &fileName, const QByteArray &fileData, const int &httpStatusCode)
+void JQHttpServer::Session::replyFile(const QString &fileName, const QByteArray &fileData, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyFile" )
 
@@ -533,7 +533,7 @@ void JQHttpServer::Session::replyFile(const QString &fileName, const QByteArray 
     socket_->write( data );
 }
 
-void JQHttpServer::Session::replyImage(const QImage &image, const QString &format, const int &httpStatusCode)
+void JQHttpServer::Session::replyImage(const QImage &image, const QString &format, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyImage" )
 
@@ -579,7 +579,7 @@ void JQHttpServer::Session::replyImage(const QImage &image, const QString &forma
     socket_->write( data );
 }
 
-void JQHttpServer::Session::replyImage(const QString &imageFilePath, const int &httpStatusCode)
+void JQHttpServer::Session::replyImage(const QString &imageFilePath, const int httpStatusCode)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyImage" )
 
@@ -617,7 +617,7 @@ void JQHttpServer::Session::replyImage(const QString &imageFilePath, const int &
     socket_->write( data );
 }
 
-void JQHttpServer::Session::replyBytes(const QByteArray &bytes, const QString &contentType, const int &httpStatusCode, const QString &exHeader)
+void JQHttpServer::Session::replyBytes(const QByteArray &bytes, const QString &contentType, const int httpStatusCode, const QString &exHeader)
 {
     JQHTTPSERVER_SESSION_REPLY_PROTECTION( "replyBytes" )
 
@@ -814,7 +814,7 @@ void JQHttpServer::Session::analyseBufferSetup2()
     handleAcceptedCallback_( this );
 }
 
-void JQHttpServer::Session::onBytesWritten(const qint64 &written)
+void JQHttpServer::Session::onBytesWritten(const qint64 written)
 {
     if ( this->waitWrittenByteCount_ < 0 ) { return; }
 
@@ -861,7 +861,7 @@ void JQHttpServer::Session::onStateChanged(const QAbstractSocket::SocketState &s
 }
 
 // AbstractManage
-JQHttpServer::AbstractManage::AbstractManage(const int &handleMaxThreadCount)
+JQHttpServer::AbstractManage::AbstractManage(const int handleMaxThreadCount)
 {
     handleThreadPool_.reset( new QThreadPool );
     serverThreadPool_.reset( new QThreadPool );
@@ -983,7 +983,7 @@ void JQHttpServer::AbstractManage::handleAccepted(const QPointer< Session > &ses
 }
 
 // TcpServerManage
-JQHttpServer::TcpServerManage::TcpServerManage(const int &handleMaxThreadCount):
+JQHttpServer::TcpServerManage::TcpServerManage(const int handleMaxThreadCount):
     AbstractManage( handleMaxThreadCount )
 { }
 
@@ -995,7 +995,7 @@ JQHttpServer::TcpServerManage::~TcpServerManage()
     }
 }
 
-bool JQHttpServer::TcpServerManage::listen(const QHostAddress &address, const quint16 &port)
+bool JQHttpServer::TcpServerManage::listen(const QHostAddress &address, const quint16 port)
 {
     listenAddress_ = address;
     listenPort_ = port;
@@ -1073,7 +1073,7 @@ void JQHttpServer::SslServerHelper::incomingConnection(qintptr socketDescriptor)
 
 }
 
-JQHttpServer::SslServerManage::SslServerManage(const int &handleMaxThreadCount):
+JQHttpServer::SslServerManage::SslServerManage(const int handleMaxThreadCount):
     AbstractManage( handleMaxThreadCount )
 { }
 
@@ -1087,7 +1087,7 @@ JQHttpServer::SslServerManage::~SslServerManage()
 
 bool JQHttpServer::SslServerManage::listen(
     const QHostAddress &address,
-    const quint16 &     port,
+    const quint16       port,
     const QString &     crtFilePath,
     const QString &     keyFilePath )
 {
@@ -1317,9 +1317,9 @@ QJsonDocument JQHttpServer::Service::extractPostJsonData(const QPointer< JQHttpS
 void JQHttpServer::Service::reply(
     const QPointer< JQHttpServer::Session > &session,
     const QJsonObject &data,
-    const bool &isSucceed,
+    const bool isSucceed,
     const QString &message,
-    const int &httpStatusCode )
+    const int httpStatusCode )
 {
     QJsonObject result;
     result[ "isSucceed" ] = isSucceed;
@@ -1335,9 +1335,9 @@ void JQHttpServer::Service::reply(
 
 void JQHttpServer::Service::reply(
     const QPointer< JQHttpServer::Session > &session,
-    const bool &isSucceed,
+    const bool isSucceed,
     const QString &message,
-    const int &httpStatusCode )
+    const int httpStatusCode )
 {
     reply( session, QJsonObject(), isSucceed, message, httpStatusCode );
 }
@@ -1577,7 +1577,7 @@ void JQHttpServer::Service::onSessionAccepted(const QPointer< JQHttpServer::Sess
     reply( session, false, "API not found", 404 );
 }
 
-QString JQHttpServer::Service::snakeCaseToCamelCase(const QString &source, const bool &firstCharUpper)
+QString JQHttpServer::Service::snakeCaseToCamelCase(const QString &source, const bool firstCharUpper)
 {
 #if ( QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 ) )
     const auto &&splitList = source.split( '_', Qt::SkipEmptyParts );

--- a/library/JQLibrary/src/jqnet.cpp
+++ b/library/JQLibrary/src/jqnet.cpp
@@ -52,7 +52,7 @@ QNetworkAddressEntry JQNet::getFirstNetworkAddressEntry()
     return list.first().first;
 }
 
-QPair< QNetworkAddressEntry, QNetworkInterface > JQNet::getFirstNetworkAddressEntryAndInterface(const bool &ridVm)
+QPair< QNetworkAddressEntry, QNetworkInterface > JQNet::getFirstNetworkAddressEntryAndInterface(const bool ridVm)
 {
     auto list = JQNet::getNetworkAddressEntryAndInterface( ridVm );
     if ( list.isEmpty() ) { return { }; }
@@ -60,7 +60,7 @@ QPair< QNetworkAddressEntry, QNetworkInterface > JQNet::getFirstNetworkAddressEn
     return list.first();
 }
 
-QList< QPair< QNetworkAddressEntry, QNetworkInterface > > JQNet::getNetworkAddressEntryAndInterface(const bool &ridVm)
+QList< QPair< QNetworkAddressEntry, QNetworkInterface > > JQNet::getNetworkAddressEntryAndInterface(const bool ridVm)
 {
     QList< QPair< QNetworkAddressEntry, QNetworkInterface > > result;
 
@@ -95,7 +95,7 @@ QString JQNet::getHostName()
 #endif
 }
 
-bool JQNet::tcpReachable(const QString &hostName, const quint16 &port, const int &timeout)
+bool JQNet::tcpReachable(const QString &hostName, const quint16 port, const int timeout)
 {
     QTcpSocket socket;
 
@@ -106,7 +106,7 @@ bool JQNet::tcpReachable(const QString &hostName, const quint16 &port, const int
 }
 
 #ifdef JQFOUNDATION_LIB
-bool JQNet::pingReachable(const QString &address, const int &timeout)
+bool JQNet::pingReachable(const QString &address, const int timeout)
 {
     QPair< int, QByteArray > pingResult = { -1, { } };
 
@@ -125,7 +125,7 @@ bool JQNet::pingReachable(const QString &address, const int &timeout)
 // HTTP
 bool JQNet::HTTP::get(
         const QNetworkRequest &request,
-        QByteArray &receiveBuffer, const int &timeout
+        QByteArray &receiveBuffer, const int timeout
     )
 {
     receiveBuffer.clear();
@@ -163,7 +163,7 @@ void JQNet::HTTP::get(
         const QNetworkRequest &request,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &)> &onFinished,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &, const QByteArray &)> &onError,
-        const int &timeout
+        const int timeout
     )
 {
     auto reply = manage().get( request );
@@ -183,7 +183,7 @@ void JQNet::HTTP::get(
 bool JQNet::HTTP::deleteResource(
         const QNetworkRequest &request,
         QByteArray &receiveBuffer,
-        const int &timeout
+        const int timeout
     )
 {
     receiveBuffer.clear();
@@ -221,7 +221,7 @@ void JQNet::HTTP::deleteResource(
         const QNetworkRequest &request,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &)> &onFinished,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &, const QByteArray &)> &onError,
-        const int &timeout
+        const int timeout
     )
 {
     auto reply = manage().deleteResource( request );
@@ -243,7 +243,7 @@ bool JQNet::HTTP::post(
         const QByteArray &body,
         QList< QNetworkReply::RawHeaderPair > &receiveRawHeaderPairs,
         QByteArray &receiveBuffer,
-        const int &timeout
+        const int timeout
     )
 {
     receiveBuffer.clear();
@@ -283,7 +283,7 @@ bool JQNet::HTTP::post(
         const QNetworkRequest &request,
         const QSharedPointer< QHttpMultiPart > &multiPart,
         QByteArray &receiveBuffer,
-        const int &timeout
+        const int timeout
     )
 {
     receiveBuffer.clear();
@@ -322,7 +322,7 @@ void JQNet::HTTP::post(
         const QByteArray &body,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &)> &onFinished,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &, const QByteArray &)> &onError,
-        const int &timeout
+        const int timeout
     )
 {
     auto reply = manage().post( request, body );
@@ -343,7 +343,7 @@ bool JQNet::HTTP::put(
         const QNetworkRequest &request,
         const QByteArray &body,
         QByteArray &receiveBuffer,
-        const int &timeout
+        const int timeout
     )
 {
     receiveBuffer.clear();
@@ -381,7 +381,7 @@ bool JQNet::HTTP::put(
         const QNetworkRequest &request,
         const QSharedPointer< QHttpMultiPart > &multiPart,
         QByteArray &receiveBuffer,
-        const int &timeout
+        const int timeout
     )
 {
     receiveBuffer.clear();
@@ -420,7 +420,7 @@ void JQNet::HTTP::put(
         const QByteArray &body,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &)> &onFinished,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &, const QByteArray &)> &onError,
-        const int &timeout
+        const int timeout
     )
 {
     auto reply = manage().put( request, body );
@@ -442,7 +442,7 @@ bool JQNet::HTTP::patch(
         const QNetworkRequest &request,
         const QByteArray &body,
         QByteArray &receiveBuffer,
-        const int &timeout
+        const int timeout
     )
 {
     receiveBuffer.clear();
@@ -481,7 +481,7 @@ void JQNet::HTTP::patch(
         const QByteArray &body,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &)> &onFinished,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &, const QByteArray &)> &onError,
-        const int &timeout
+        const int timeout
     )
 {
     auto reply = manage().sendCustomRequest( request, "PATCH", body );
@@ -499,7 +499,7 @@ void JQNet::HTTP::patch(
 }
 #endif
 
-QPair< bool, QByteArray > JQNet::HTTP::get(const QString &url, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::get(const QString &url, const int timeout)
 {
     QNetworkRequest networkRequest( ( QUrl( url ) ) );
     QByteArray receiveBuffer;
@@ -509,7 +509,7 @@ QPair< bool, QByteArray > JQNet::HTTP::get(const QString &url, const int &timeou
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::get(const QNetworkRequest &request, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::get(const QNetworkRequest &request, const int timeout)
 {
     QByteArray receiveBuffer;
     HTTP http;
@@ -519,7 +519,7 @@ QPair< bool, QByteArray > JQNet::HTTP::get(const QNetworkRequest &request, const
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::deleteResource(const QString &url, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::deleteResource(const QString &url, const int timeout)
 {
     QNetworkRequest networkRequest( ( QUrl( url ) ) );
     QByteArray receiveBuffer;
@@ -529,7 +529,7 @@ QPair< bool, QByteArray > JQNet::HTTP::deleteResource(const QString &url, const 
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::deleteResource(const QNetworkRequest &request, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::deleteResource(const QNetworkRequest &request, const int timeout)
 {
     QByteArray receiveBuffer;
     HTTP http;
@@ -539,7 +539,7 @@ QPair< bool, QByteArray > JQNet::HTTP::deleteResource(const QNetworkRequest &req
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::post(const QString &url, const QByteArray &body, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::post(const QString &url, const QByteArray &body, const int timeout)
 {
     QNetworkRequest networkRequest( ( QUrl( url ) ) );
     QList< QNetworkReply::RawHeaderPair > rawHeaderPairs;
@@ -552,7 +552,7 @@ QPair< bool, QByteArray > JQNet::HTTP::post(const QString &url, const QByteArray
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::post(const QNetworkRequest &request, const QByteArray &body, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::post(const QNetworkRequest &request, const QByteArray &body, const int timeout)
 {
     QByteArray receiveBuffer;
     QList< QNetworkReply::RawHeaderPair > rawHeaderPairs;
@@ -563,7 +563,7 @@ QPair< bool, QByteArray > JQNet::HTTP::post(const QNetworkRequest &request, cons
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QPair< QList< QNetworkReply::RawHeaderPair >, QByteArray > > JQNet::HTTP::post2(const QNetworkRequest &request, const QByteArray &body, const int &timeout)
+QPair< bool, QPair< QList< QNetworkReply::RawHeaderPair >, QByteArray > > JQNet::HTTP::post2(const QNetworkRequest &request, const QByteArray &body, const int timeout)
 {
     QByteArray receiveBuffer;
     QList< QNetworkReply::RawHeaderPair > rawHeaderPairs;
@@ -574,7 +574,7 @@ QPair< bool, QPair< QList< QNetworkReply::RawHeaderPair >, QByteArray > > JQNet:
     return { isSucceed, { rawHeaderPairs, receiveBuffer } };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::post(const QNetworkRequest &request, const QSharedPointer<QHttpMultiPart> &multiPart, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::post(const QNetworkRequest &request, const QSharedPointer<QHttpMultiPart> &multiPart, const int timeout)
 {
     QByteArray receiveBuffer;
     HTTP http;
@@ -584,7 +584,7 @@ QPair< bool, QByteArray > JQNet::HTTP::post(const QNetworkRequest &request, cons
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::put(const QString &url, const QByteArray &body, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::put(const QString &url, const QByteArray &body, const int timeout)
 {
     QNetworkRequest networkRequest( ( QUrl( url ) ) );
     QByteArray receiveBuffer;
@@ -596,7 +596,7 @@ QPair< bool, QByteArray > JQNet::HTTP::put(const QString &url, const QByteArray 
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::put(const QNetworkRequest &request, const QByteArray &body, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::put(const QNetworkRequest &request, const QByteArray &body, const int timeout)
 {
     QByteArray receiveBuffer;
     HTTP http;
@@ -606,7 +606,7 @@ QPair< bool, QByteArray > JQNet::HTTP::put(const QNetworkRequest &request, const
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::put(const QNetworkRequest &request, const QSharedPointer< QHttpMultiPart > &multiPart, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::put(const QNetworkRequest &request, const QSharedPointer< QHttpMultiPart > &multiPart, const int timeout)
 {
     QByteArray receiveBuffer;
     HTTP http;
@@ -617,7 +617,7 @@ QPair< bool, QByteArray > JQNet::HTTP::put(const QNetworkRequest &request, const
 }
 
 #if !( defined Q_OS_LINUX ) && ( QT_VERSION >= QT_VERSION_CHECK( 5, 9, 0 ) )
-QPair< bool, QByteArray > JQNet::HTTP::patch(const QString &url, const QByteArray &body, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::patch(const QString &url, const QByteArray &body, const int timeout)
 {
     QNetworkRequest networkRequest( ( QUrl( url ) ) );
     QByteArray receiveBuffer;
@@ -629,7 +629,7 @@ QPair< bool, QByteArray > JQNet::HTTP::patch(const QString &url, const QByteArra
     return { isSucceed, receiveBuffer };
 }
 
-QPair< bool, QByteArray > JQNet::HTTP::patch(const QNetworkRequest &request, const QByteArray &body, const int &timeout)
+QPair< bool, QByteArray > JQNet::HTTP::patch(const QNetworkRequest &request, const QByteArray &body, const int timeout)
 {
     QByteArray receiveBuffer;
     HTTP http;
@@ -642,7 +642,7 @@ QPair< bool, QByteArray > JQNet::HTTP::patch(const QNetworkRequest &request, con
 
 void JQNet::HTTP::handle(
         QNetworkReply *reply,
-        const int &timeout,
+        const int timeout,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QByteArray &)> &onFinished,
         const std::function<void (const QList< QNetworkReply::RawHeaderPair > &, const QNetworkReply::NetworkError &, const QByteArray &data)> &onError,
         const std::function<void ()> &onTimeout


### PR DESCRIPTION
## Summary
- use const for primitive parameters while keeping value semantics

## Testing
- None

------
https://chatgpt.com/codex/tasks/task_e_684a37ea2a2c83249a839998c4f191ca